### PR TITLE
Add xlppChan meta field in sensor presets

### DIFF
--- a/Gateway/scripts/add_full_tensiometer_device.sh
+++ b/Gateway/scripts/add_full_tensiometer_device.sh
@@ -2,6 +2,8 @@
 
 # this script adds a watermark sensor as secondary device, i.e. SOIL-AREA-2 and devAddr=26011DB2
 # could be replaced by create_full_tensiometer_device_with_dev_addr.sh 2 B2
+./create_full_tensiometer_device_with_dev_addr.sh 2 B2
+exit
 
 echo "--> Adding an additional device to the existing device"
 

--- a/Gateway/scripts/add_to_iiwa_devices.sh
+++ b/Gateway/scripts/add_to_iiwa_devices.sh
@@ -6,21 +6,21 @@
 
 if [ $3 == 'tensiometer' ]
 then
-    STYPE="watermark"
-    SAMOUNT="1"
+	STYPE="watermark"
+	SAMOUNT="1"
 elif [ $3 == '2tensiometers' ]
 then
 	STYPE="watermark"
-    SAMOUNT="2"
+	SAMOUNT="2"
 else
 	STYPE=$3
-    SAMOUNT="1"
+	SAMOUNT="1"
 fi
 
 tmpfile=$(mktemp)
 
 jq ". + [{ \
-    \"device_id\": \"${1}\", \
-    \"device_name\": \"SOIL-AREA-${2}\", \
-    \"sensors_structure\": \"${SAMOUNT}_${STYPE}\" \
-    }]" intel_irris_devices.json > "$tmpfile" && mv -- "$tmpfile" intel_irris_devices.json
+	\"device_id\": \"${1}\", \
+	\"device_name\": \"SOIL-AREA-${2}\", \
+	\"sensors_structure\": \"${SAMOUNT}_${STYPE}\" \
+	}]" intel_irris_devices.json > "$tmpfile" && mv -- "$tmpfile" intel_irris_devices.json

--- a/Gateway/scripts/create_full_2-tensiometer_device_with_dev_addr.sh
+++ b/Gateway/scripts/create_full_2-tensiometer_device_with_dev_addr.sh
@@ -20,7 +20,91 @@ DATE=`date +"%Y-%m-%dT06:00:00.001Z"`
 echo "--> Use date of $DATE"
 echo "--> Create new device"
 
-DEVICE=`curl -X POST "http://localhost/devices" -H "accept: application/json" -H "Authorization: Bearer $TOK" -H  "Content-Type: application/json" -d "{\"actuators\":[],\"name\":\"SOIL-AREA-${1}\",\"sensors\":[{\"id\":\"temperatureSensor_0\",\"kind\":\"\",\"meta\":{\"createdBy\":\"wazigate-lora\",\"kind\":\"centibars from WM200\",\"model\":\"WM200\",\"type\":\"tensiometer\",\"sensor_dry_max\":124,\"sensor_wet_max\":0,\"sensor_n_interval\":6,\"value_index\":0},\"name\":\"Watermark 1\",\"quantity\":\"\",\"time\":\"$DATE\",\"unit\":\"\",\"value\":10},{\"id\":\"temperatureSensor_1\",\"kind\":\"\",\"meta\":{\"createdBy\":\"wazigate-lora\",\"kind\":\"scaled value from WM200 real=x10\",\"model\":\"WM200\",\"type\":\"tensiometer\",\"sensor_dry_max\":18000,\"sensor_wet_max\":0,\"sensor_n_interval\":6,\"value_index\":0},\"name\":\"Watermark 1\",\"quantity\":\"\",\"time\":\"$DATE\",\"unit\":\"\",\"value\":550},{\"id\":\"temperatureSensor_2\",\"kind\":\"\",\"meta\":{\"createdBy\":\"wazigate-lora\",\"kind\":\"centibars from WM200\",\"model\":\"WM200\",\"type\":\"tensiometer\",\"sensor_dry_max\":124,\"sensor_wet_max\":0,\"sensor_n_interval\":6,\"value_index\":0},\"name\":\"Watermark 2\",\"quantity\":\"\",\"time\":\"$DATE\",\"unit\":\"\",\"value\":10},{\"id\":\"temperatureSensor_3\",\"kind\":\"\",\"meta\":{\"createdBy\":\"wazigate-lora\",\"kind\":\"scaled value from WM200 real=x10\",\"model\":\"WM200\",\"type\":\"tensiometer\",\"sensor_dry_max\":18000,\"sensor_wet_max\":0,\"sensor_n_interval\":6,\"value_index\":0},\"name\":\"Watermark 2\",\"quantity\":\"\",\"time\":\"$DATE\",\"unit\":\"\",\"value\":550}]}" | tr -d '\"'`
+DEVICE=`curl -X POST "http://localhost/devices" -H "accept: application/json" -H "Authorization: Bearer $TOK" -H  "Content-Type: application/json" -d "{
+  \"actuators\":[],
+  \"name\":\"SOIL-AREA-${1}\",
+  \"sensors\":[
+  {
+    \"id\":\"temperatureSensor_0\",
+    \"kind\":\"\",
+    \"meta\":
+    {
+      \"xlppChan\":0,
+      \"createdBy\":\"wazigate-lora\",
+      \"kind\":\"centibars from WM200\",
+      \"model\":\"WM200\",
+      \"type\":\"tensiometer\",
+      \"sensor_dry_max\":124,
+      \"sensor_wet_max\":0,
+      \"sensor_n_interval\":6,
+      \"value_index\":0
+    },
+    \"name\":\"Watermark 1\",
+    \"quantity\":\"\",
+    \"time\":\"$DATE\",
+    \"unit\":\"\",
+    \"value\":10
+  },{
+    \"id\":\"temperatureSensor_1\",
+    \"kind\":\"\",
+    \"meta\":
+    {
+      \"xlppChan\":1,
+      \"createdBy\":\"wazigate-lora\",
+      \"kind\":\"scaled value from WM200 real=x10\",
+      \"model\":\"WM200\",
+      \"type\":\"tensiometer\",
+      \"sensor_dry_max\":18000,
+      \"sensor_wet_max\":0,
+      \"sensor_n_interval\":6,
+      \"value_index\":0
+    },
+    \"name\":\"Watermark 1\",
+    \"quantity\":\"\",
+    \"time\":\"$DATE\",
+    \"unit\":\"\",
+    \"value\":550
+  },{
+    \"id\":\"temperatureSensor_2\",
+    \"kind\":\"\",
+    \"meta\":
+    {
+      \"xlppChan\":2,
+      \"createdBy\":\"wazigate-lora\",
+      \"kind\":\"centibars from WM200\",
+      \"model\":\"WM200\",
+      \"type\":\"tensiometer\",
+      \"sensor_dry_max\":124,
+      \"sensor_wet_max\":0,
+      \"sensor_n_interval\":6,
+      \"value_index\":0
+    },
+    \"name\":\"Watermark 2\",
+    \"quantity\":\"\",
+    \"time\":\"$DATE\",
+    \"unit\":\"\",
+    \"value\":10
+  },{
+    \"id\":\"temperatureSensor_3\",
+    \"kind\":\"\",
+    \"meta\":
+    {
+      \"xlppChan\":3,
+      \"createdBy\":\"wazigate-lora\",
+      \"kind\":\"scaled value from WM200 real=x10\",
+      \"model\":\"WM200\",
+      \"type\":\"tensiometer\",
+      \"sensor_dry_max\":18000,
+      \"sensor_wet_max\":0,
+      \"sensor_n_interval\":6,
+      \"value_index\":0
+    },
+    \"name\":\"Watermark 2\",
+    \"quantity\":\"\",
+    \"time\":\"$DATE\",
+    \"unit\":\"\",
+    \"value\":550
+  }]}" | tr -d '\"'`
 
 echo $DEVICE > /home/pi/scripts/LAST_CREATED_DEVICE.txt
 echo "device $DEVICE"

--- a/Gateway/scripts/create_full_capacitive_device.sh
+++ b/Gateway/scripts/create_full_capacitive_device.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
 # this script creates a SEN0308 sensor as primary device, i.e. SOIL-AREA-1 and devAddr=26011DAA
+./create_full_capacitive_device_with_dev_addr.sh 1 AA
+exit
 
 echo "--> Get token"
 TOK=`curl -X POST "http://localhost/auth/token" -H  "accept: application/json" -H  "Content-Type: application/json" -d "{\"username\":\"admin\",\"password\":\"loragateway\"}" | tr -d '\"'`

--- a/Gateway/scripts/create_full_capacitive_device_with_dev_addr.sh
+++ b/Gateway/scripts/create_full_capacitive_device_with_dev_addr.sh
@@ -20,7 +20,31 @@ DATE=`date +"%Y-%m-%dT06:00:00.001Z"`
 echo "--> Use date of $DATE"
 echo "--> Create new device"
 
-DEVICE=`curl -X POST "http://localhost/devices" -H "accept: application/json" -H "Authorization: Bearer $TOK" -H  "Content-Type: application/json" -d "{\"actuators\":[],\"name\":\"SOIL-AREA-${1}\",\"sensors\":[{\"id\":\"temperatureSensor_0\",\"kind\":\"\",\"meta\":{\"createdBy\":\"wazigate-lora\",\"kind\":\"Raw value from SEN0308\",\"model\":\"SEN0308\",\"type\":\"capacitive\",\"sensor_dry_max\":800,\"sensor_wet_max\":0,\"sensor_n_interval\":6,\"value_index\":0},\"name\":\"Soil Humidity Sensor\",\"quantity\":\"\",\"time\":\"$DATE\",\"unit\":\"\",\"value\":800}]}" | tr -d '\"'`
+DEVICE=`curl -X POST "http://localhost/devices" -H "accept: application/json" -H "Authorization: Bearer $TOK" -H  "Content-Type: application/json" -d "{
+  \"actuators\":[],
+  \"name\":\"SOIL-AREA-${1}\",
+  \"sensors\":[
+  {
+    \"id\":\"temperatureSensor_0\",
+    \"kind\":\"\",
+    \"meta\":
+    {
+      \"xlppChan\":0,
+      \"createdBy\":\"wazigate-lora\",
+      \"kind\":\"Raw value from SEN0308\",
+      \"model\":\"SEN0308\",
+      \"type\":\"capacitive\",
+      \"sensor_dry_max\":800,
+      \"sensor_wet_max\":0,
+      \"sensor_n_interval\":6,
+      \"value_index\":0
+    },
+    \"name\":\"Soil Humidity Sensor\",
+    \"quantity\":\"\",
+    \"time\":\"$DATE\",
+    \"unit\":\"\",
+    \"value\":800
+  }]}" | tr -d '\"'`
 
 echo $DEVICE > /home/pi/scripts/LAST_CREATED_DEVICE.txt
 echo "device $DEVICE"

--- a/Gateway/scripts/create_full_tensiometer_device.sh
+++ b/Gateway/scripts/create_full_tensiometer_device.sh
@@ -2,6 +2,8 @@
 
 # this script creates the default watermark sensor, i.e. SOIL-AREA-1 and devAddr=26011DB1
 # could be replaced by create_full_tensiometer_device_with_dev_addr.sh 1 B1
+./create_full_tensiometer_device_with_dev_addr.sh 1 B1
+exit
 
 echo "--> Get token"
 TOK=`curl -X POST "http://localhost/auth/token" -H  "accept: application/json" -H  "Content-Type: application/json" -d "{\"username\":\"admin\",\"password\":\"loragateway\"}" | tr -d '\"'`

--- a/Gateway/scripts/create_full_tensiometer_device_with_dev_addr.sh
+++ b/Gateway/scripts/create_full_tensiometer_device_with_dev_addr.sh
@@ -20,7 +20,51 @@ DATE=`date +"%Y-%m-%dT06:00:00.001Z"`
 echo "--> Use date of $DATE"
 echo "--> Create new device"
 
-DEVICE=`curl -X POST "http://localhost/devices" -H "accept: application/json" -H "Authorization: Bearer $TOK" -H  "Content-Type: application/json" -d "{\"actuators\":[],\"name\":\"SOIL-AREA-${1}\",\"sensors\":[{\"id\":\"temperatureSensor_0\",\"kind\":\"\",\"meta\":{\"createdBy\":\"wazigate-lora\",\"kind\":\"centibars from WM200\",\"model\":\"WM200\",\"type\":\"tensiometer\",\"sensor_dry_max\":124,\"sensor_wet_max\":0,\"sensor_n_interval\":6,\"value_index\":0},\"name\":\"Soil Humidity Sensor\",\"quantity\":\"\",\"time\":\"$DATE\",\"unit\":\"\",\"value\":10},{\"id\":\"temperatureSensor_1\",\"kind\":\"\",\"meta\":{\"createdBy\":\"wazigate-lora\",\"kind\":\"scaled value from WM200 real=x10\",\"model\":\"WM200\",\"type\":\"tensiometer\",\"sensor_dry_max\":18000,\"sensor_wet_max\":0,\"sensor_n_interval\":6,\"value_index\":0},\"name\":\"Soil Humidity Sensor\",\"quantity\":\"\",\"time\":\"$DATE\",\"unit\":\"\",\"value\":550}]}" | tr -d '\"'`
+DEVICE=`curl -X POST "http://localhost/devices" -H "accept: application/json" -H "Authorization: Bearer $TOK" -H  "Content-Type: application/json" -d "{
+  \"actuators\":[],
+  \"name\":\"SOIL-AREA-${1}\",
+  \"sensors\":[
+  {
+    \"id\":\"temperatureSensor_0\",
+    \"kind\":\"\",
+    \"meta\":
+    {
+      \"xlppChan\":0,
+      \"createdBy\":\"wazigate-lora\",
+      \"kind\":\"centibars from WM200\",
+      \"model\":\"WM200\",
+      \"type\":\"tensiometer\",
+      \"sensor_dry_max\":124,
+      \"sensor_wet_max\":0,
+      \"sensor_n_interval\":6,
+      \"value_index\":0
+    },
+    \"name\":\"Soil Humidity Sensor\",
+    \"quantity\":\"\",
+    \"time\":\"$DATE\",
+    \"unit\":\"\",
+    \"value\":10
+  },{
+    \"id\":\"temperatureSensor_1\",
+    \"kind\":\"\",
+    \"meta\":
+    {
+      \"xlppChan\":1,
+      \"createdBy\":\"wazigate-lora\",
+      \"kind\":\"scaled value from WM200 real=x10\",
+      \"model\":\"WM200\",
+      \"type\":\"tensiometer\",
+      \"sensor_dry_max\":18000,
+      \"sensor_wet_max\":0,
+      \"sensor_n_interval\":6,
+      \"value_index\":0
+    },
+    \"name\":\"Soil Humidity Sensor\",
+    \"quantity\":\"\",
+    \"time\":\"$DATE\",
+    \"unit\":\"\",
+    \"value\":550
+  }]}" | tr -d '\"'`
 
 echo $DEVICE > /home/pi/scripts/LAST_CREATED_DEVICE.txt
 echo "device $DEVICE"

--- a/Gateway/scripts/create_only_capacitive_sensor.sh
+++ b/Gateway/scripts/create_only_capacitive_sensor.sh
@@ -19,7 +19,27 @@ echo "--> Use date of $DATE"
 echo "--> Use device $1"
 echo "--> Create capacitive sensor"
 
-curl -X POST "http://localhost/devices/$1/sensors" -H "accept: application/json" -H "Authorization: Bearer $TOK" -H  "Content-Type: application/json" -d "{\"id\":\"temperatureSensor_0\",\"kind\":\"\",\"meta\":{\"createdBy\":\"wazigate-lora\",\"kind\":\"Raw value from SEN0308\",\"model\":\"SEN0308\",\"type\":\"capacitive\",\"sensor_dry_max\":800,\"sensor_wet_max\":0,\"sensor_n_interval\":6,\"value_index\":0},\"name\":\"Soil Humidity Sensor\",\"quantity\":\"\",\"time\":\"$DATE\",\"unit\":\"\",\"value\":800}"
+curl -X POST "http://localhost/devices/$1/sensors" -H "accept: application/json" -H "Authorization: Bearer $TOK" -H  "Content-Type: application/json" -d "{
+  \"id\":\"temperatureSensor_0\",
+  \"kind\":\"\",
+  \"meta\":
+  {
+    \"xlppChan\":0,
+    \"createdBy\":\"wazigate-lora\",
+    \"kind\":\"Raw value from SEN0308\",
+    \"model\":\"SEN0308\",
+    \"type\":\"capacitive\",
+    \"sensor_dry_max\":800,
+    \"sensor_wet_max\":0,
+    \"sensor_n_interval\":6,
+    \"value_index\":0
+  },
+  \"name\":\"Soil Humidity Sensor\",
+  \"quantity\":\"\",
+  \"time\":\"$DATE\",
+  \"unit\":\"\",
+  \"value\":800
+}"
 
 echo "device $1"
 echo "		with Soil Humidity Sensor displaying Raw value from SEN0308"

--- a/Gateway/scripts/create_only_empty_capacitive_sensor.sh
+++ b/Gateway/scripts/create_only_empty_capacitive_sensor.sh
@@ -18,7 +18,27 @@ echo "--> Use date of $DATE"
 echo "--> Use device $1"
 echo "--> Create capacitive sensor"
 
-curl -X POST "http://localhost/devices/$1/sensors" -H "accept: application/json" -H "Authorization: Bearer $TOK" -H  "Content-Type: application/json" -d "{\"id\":\"temperatureSensor_0\",\"kind\":\"\",\"meta\":{\"createdBy\":\"wazigate-lora\",\"kind\":\"\",\"model\":\"SEN0308\",\"type\":\"capacitive\",\"sensor_dry_max\":800,\"sensor_wet_max\":0,\"sensor_n_interval\":6,\"value_index\":0},\"name\":\"temperatureSensor_0\",\"quantity\":\"\",\"time\":\"$DATE\",\"unit\":\"\",\"value\":800}"
+curl -X POST "http://localhost/devices/$1/sensors" -H "accept: application/json" -H "Authorization: Bearer $TOK" -H  "Content-Type: application/json" -d "{
+  \"id\":\"temperatureSensor_0\",
+  \"kind\":\"\",
+  \"meta\":
+  {
+    \"xlppChan\":0,
+    \"createdBy\":\"wazigate-lora\",
+    \"kind\":\"\",
+    \"model\":\"SEN0308\",
+    \"type\":\"capacitive\",
+    \"sensor_dry_max\":800,
+    \"sensor_wet_max\":0,
+    \"sensor_n_interval\":6,
+    \"value_index\":0
+  },
+  \"name\":\"temperatureSensor_0\",
+  \"quantity\":\"\",
+  \"time\":\"$DATE\",
+  \"unit\":\"\",
+  \"value\":800
+}"
 
 echo "device $1"
 echo "		with temperatureSensor_0 displaying no kind"

--- a/Gateway/scripts/create_only_temperature_sensor.sh
+++ b/Gateway/scripts/create_only_temperature_sensor.sh
@@ -21,7 +21,24 @@ echo "--> Use date of $DATE"
 echo "--> Use device ${1}"
 echo "--> Create temperature sensor"
 
-curl -X POST "http://localhost/devices/${1}/sensors" -H "accept: application/json" -H "Authorization: Bearer $TOK" -H  "Content-Type: application/json" -d "{\"id\":\"temperatureSensor_5\",\"kind\":\"\",\"meta\":{\"createdBy\":\"wazigate-lora\",\"kind\":\"degree Celsius\",\"model\":\"DS18B20\",\"type\":\"temperature\",\"value_index\":0},\"name\":\"Soil Temperature Sensor\",\"quantity\":\"\",\"time\":\"$DATE\",\"unit\":\"\",\"value\":-99}"
+curl -X POST "http://localhost/devices/${1}/sensors" -H "accept: application/json" -H "Authorization: Bearer $TOK" -H  "Content-Type: application/json" -d "{
+  \"id\":\"temperatureSensor_5\",
+  \"kind\":\"\",
+  \"meta\":
+  {
+    \"xlppChan\":5,
+    \"createdBy\":\"wazigate-lora\",
+    \"kind\":\"degree Celsius\",
+    \"model\":\"DS18B20\",
+    \"type\":\"temperature\",
+    \"value_index\":0
+  },
+  \"name\":\"Soil Temperature Sensor\",
+  \"quantity\":\"\",
+  \"time\":\"$DATE\",
+  \"unit\":\"\",
+  \"value\":-99
+}"
 
 echo "device $1"
 echo "		with soil temperature displaying degree Celsius"

--- a/Gateway/scripts/create_only_voltage_monitor_sensor.sh
+++ b/Gateway/scripts/create_only_voltage_monitor_sensor.sh
@@ -21,7 +21,21 @@ echo "--> Use date of $DATE"
 echo "--> Use device ${1}"
 echo "--> Create voltage monitor sensor"
 
-curl -X POST "http://localhost/devices/${1}/sensors" -H "accept: application/json" -H "Authorization: Bearer $TOK" -H  "Content-Type: application/json" -d "{\"id\":\"analogInput_6\",\"kind\":\"\",\"meta\":{\"createdBy\":\"wazigate-lora\",\"kind\":\"volt, low battery when lower than 2.85V\"},\"name\":\"Battery voltage\",\"quantity\":\"\",\"time\":\"$DATE\",\"unit\":\"\",\"value\":-1}"
+curl -X POST "http://localhost/devices/${1}/sensors" -H "accept: application/json" -H "Authorization: Bearer $TOK" -H  "Content-Type: application/json" -d "{
+  \"id\":\"analogInput_6\",
+  \"kind\":\"\",
+  \"meta\":
+  {
+    \"xlppChan\":6,
+    \"createdBy\":\"wazigate-lora\",
+    \"kind\":\"volt, low battery when lower than 2.85V\"
+  },
+  \"name\":\"Battery voltage\",
+  \"quantity\":\"\",
+  \"time\":\"$DATE\",
+  \"unit\":\"\",
+  \"value\":-1
+}"
 
 echo "device $1"
 echo "		with voltage monitor displaying volt"


### PR DESCRIPTION
WaziGate 2.3.2 requires this field in sensor.meta in order to match received values from field sensor to a sensor preexisting in wazigate.