### PR TITLE
Bug boot custom multiple iiwa

### DIFF
--- a/Gateway/boot/create-custom-multiple-iiwa/README.md
+++ b/Gateway/boot/create-custom-multiple-iiwa/README.md
@@ -7,5 +7,6 @@ create-custom-multiple-iiwa (still under testing)
 This script takes a sequence of argument triplets:
     `sudo ./boot/create-custom-multiple-iiwa/intel-irris-auto-config.sh C 1 AE WT 8 B4`
 will for example generate the configuration (dashboard and iiwa) for a capacitive device (devAddr AE) and a watermark + temperature device (devAddr B4).
+For a device with two tensiometers and temperature, type 2WT.
 
 A default value (C 1 AA WT 2 B1) is chosen for a (first, bootstrap) argument-less configuration

--- a/Gateway/boot/create-custom-multiple-iiwa/README.md
+++ b/Gateway/boot/create-custom-multiple-iiwa/README.md
@@ -10,3 +10,5 @@ will for example generate the configuration (dashboard and iiwa) for a capacitiv
 For a device with two tensiometers and temperature, type 2WT.
 
 A default value (C 1 AA WT 2 B1) is chosen for a (first, bootstrap) argument-less configuration
+A list of bootstrap values may also be prepared in `/boot/devices.txt`.
+

--- a/Gateway/boot/create-custom-multiple-iiwa/intel-irris-auto-config.sh
+++ b/Gateway/boot/create-custom-multiple-iiwa/intel-irris-auto-config.sh
@@ -12,11 +12,11 @@ if [ $# -eq 0 ]
     echo "will create 1 capacitive SOIL-AREA-1 with address 26011DAE"
     echo "and 1 watermark with temperature sensor SOIL-AREA-8 with address 26011DB4"
     echo "for a double WM + temperature : 2WT"
-    echo "Default-1: (previous) config if any in file /home/pi/boot/devices.txt"
+    echo "Default-1: (previous) config if any in file /boot/devices.txt"
     echo "Default-2: C 1 AA WT 2 B1"
 
     #default-1: file exists and is non empty
-    FILE=/home/pi/boot/devices.txt
+    FILE=/boot/devices.txt
     if test -f "$FILE"; then
       # echo "$FILE exists."
       if test -s "$FILE"; then
@@ -31,7 +31,7 @@ if [ $# -eq 0 ]
     exit
 fi
 
-echo "$@" > /home/pi/boot/devices.txt
+echo "$@" > /boot/devices.txt
 
 cd /home/pi/scripts
 

--- a/Gateway/boot/create-custom-multiple-iiwa/intel-irris-auto-config.sh
+++ b/Gateway/boot/create-custom-multiple-iiwa/intel-irris-auto-config.sh
@@ -2,6 +2,8 @@
 
 logger -t intel-irris-auto-config "create-custom-multiple-iiwa"
 
+cd /home/pi
+
 if [ $# -eq 0 ]
   then
     echo "No arguments supplied"
@@ -78,11 +80,6 @@ do
             echo "--> set default configuration for $DEVICE in IIWA" >> /boot/intel-irris-auto-config.log
             ./add_to_iiwa_config.sh $DEVICE capacitive
 
-            #and make it the active device
-            echo "--> make $DEVICE the active device for IIWA" >> /boot/intel-irris-auto-config.log
-            echo "[]" >> intel_irris_active_device.json
-            tmpfile=$(mktemp)
-            jq ". += [{\"device_id\":\"${DEVICE}\",\"sensor_id\":\"temperatureSensor_0\"}]" intel_irris_active_device.json > "$tmpfile" && mv -- "$tmpfile" intel_irris_active_device.json
 
           elif [ "$DEVTYPE" = "WT" ]; then
             #create tensiometer SOIL-AREA-2 (after capas) and device with address 26011DB1, b2, b3,...
@@ -97,14 +94,6 @@ do
             #add the voltage monitor sensor
             echo "--> calling create_only_voltage_monitor_sensor.sh $DEVICE" >> /boot/intel-irris-auto-config.log
             ./create_only_voltage_monitor_sensor.sh $DEVICE
-
-            # echo "--> add $DEVICE to IIWA" >> /boot/intel-irris-auto-config.log
-            # echo "{\"device_id\": \"$DEVICE\", \"device_name\": \"SOIL-AREA-$DEVID\", \"sensors_structure\": \"1_watermark\"}," >> /home/pi/intel-irris-waziapp/config/intel-irris-devices.json
-
-            # echo "--> set default configuration for $DEVICE in IIWA" >> /boot/intel-irris-auto-config.log
-            # cp IIWA-templates/IIWA-wm-st.json IIWA-temp.json
-            # sed -i "s/XXX2/$DEVICE/g" IIWA-temp.json
-            # cat IIWA-temp.json >> /home/pi/intel-irris-waziapp/config/intel-irris-conf.json
 
             #IIWA, then add second tensiometer device id
             echo "--> add $DEVICE to IIWA" >> /boot/intel-irris-auto-config.log
@@ -126,14 +115,6 @@ do
             echo "--> calling create_only_voltage_monitor_sensor.sh $DEVICE" >> /boot/intel-irris-auto-config.log
             ./create_only_voltage_monitor_sensor.sh $DEVICE
 
-            # echo "--> add $DEVICE to IIWA" >> /boot/intel-irris-auto-config.log
-            # echo "{\"device_id\": \"$DEVICE\", \"device_name\": \"SOIL-AREA-$DEVID\", \"sensors_structure\": \"1_watermark\"}," >> /home/pi/intel-irris-waziapp/config/intel-irris-devices.json
-
-            # echo "--> set default configuration for $DEVICE in IIWA" >> /boot/intel-irris-auto-config.log
-            # cp IIWA-templates/IIWA-wm-st.json IIWA-temp.json
-            # sed -i "s/XXX2/$DEVICE/g" IIWA-temp.json
-            # cat IIWA-temp.json >> /home/pi/intel-irris-waziapp/config/intel-irris-conf.json
-
             #IIWA, then add second tensiometer device id
             echo "--> add $DEVICE to IIWA" >> /boot/intel-irris-auto-config.log
             ./add_to_iiwa_devices.sh $DEVICE $DEVID 2tensiometers
@@ -153,14 +134,13 @@ rm /home/pi/scripts/LAST_CREATED_DEVICE.txt
 
 #IIWA, finally, copy IIWA config file into /home/pi/intel-irris-waziapp/config/ for backup
 echo "--> copy new IIWA configuration files to /home/pi/intel-irris-waziapp/config/ for backup" >> /boot/intel-irris-auto-config.log
-cp intel_irris_devices.json intel_irris_active_device.json intel_irris_sensors_configurations.json /home/pi/intel-irris-waziapp/config/
+cp intel_irris_devices.json intel_irris_sensors_configurations.json /home/pi/intel-irris-waziapp/config/
 
 #IIWA, finally, copy IIWA config file into container
 echo "--> copy new IIWA configuration files to IIWA container" >> /boot/intel-irris-auto-config.log
 docker cp intel_irris_devices.json waziup.intel-irris-waziapp:/root/src/config
-docker cp intel_irris_active_device.json waziup.intel-irris-waziapp:/root/src/config
 docker cp intel_irris_sensors_configurations.json waziup.intel-irris-waziapp:/root/src/config
 
 echo "--> removing IIWA configuration files" >> /boot/intel-irris-auto-config.log
-rm -rf intel_irris_devices.json intel_irris_active_device.json intel_irris_sensors_configurations.json
+rm -rf intel_irris_devices.json intel_irris_sensors_configurations.json
 

--- a/Gateway/boot/create-custom-multiple-range-iiwa/README.md
+++ b/Gateway/boot/create-custom-multiple-range-iiwa/README.md
@@ -8,5 +8,9 @@ This script takes two integer arguments:
     `sudo ./boot/create-custom-multiple-range-iiwa/intel-irris-auto-config.sh 3 9`
 will for example generate the configuration (dashboard and iiwa) for three capacitive sensors (devAddr AA, AB, AC) and 9 watermark + temperature devices (devAddr B1, B2, ..., B9).
 
-A default value (2 2) is chosen for a (first, bootstrap) argument-less configuration
+A default value (2 2) is chosen for a (first, bootstrap) argument-less configuration.
+A pair of bootstrap values may also be prepared in `/boot/capas.txt` and `/boot/watermarks.txt`.
+For example:
+`echo 4 > /boot/capas.txt`
+
 

--- a/Gateway/boot/create-custom-multiple-range-iiwa/intel-irris-auto-config.sh
+++ b/Gateway/boot/create-custom-multiple-range-iiwa/intel-irris-auto-config.sh
@@ -2,6 +2,8 @@
 
 logger -t intel-irris-auto-config "create-custom-multiple-range-iiwa"
 
+cd /home/pi
+
 if [ $# -eq 0 ]
   then
     FILE=/home/pi/boot/watermarks.txt
@@ -60,12 +62,6 @@ do
   ./add_to_iiwa_devices.sh $DEVICE $i capacitive
   echo "--> set default configuration for $DEVICE in IIWA" >> /boot/intel-irris-auto-config.log
   ./add_to_iiwa_config.sh $DEVICE capacitive
-
-  #and make it the active device
-  echo "--> make $DEVICE the active device for IIWA" >> /boot/intel-irris-auto-config.log
-  echo "[]" >> intel_irris_active_device.json
-  tmpfile=$(mktemp)
-  jq ". += [{\"device_id\":\"${DEVICE}\",\"sensor_id\":\"temperatureSensor_0\"}]" intel_irris_active_device.json > "$tmpfile" && mv -- "$tmpfile" intel_irris_active_device.json
 done
 
 # iterate over WM-st devices
@@ -99,16 +95,15 @@ rm /home/pi/scripts/LAST_CREATED_DEVICE.txt
 
 #IIWA, finally, copy IIWA config file into /home/pi/intel-irris-waziapp/config/ for backup
 echo "--> copy new IIWA configuration files to /home/pi/intel-irris-waziapp/config/ for backup" >> /boot/intel-irris-auto-config.log
-cp intel_irris_devices.json intel_irris_active_device.json intel_irris_sensors_configurations.json /home/pi/intel-irris-waziapp/config/
+cp intel_irris_devices.json  intel_irris_sensors_configurations.json /home/pi/intel-irris-waziapp/config/
 
 #IIWA, finally, copy IIWA config file into container
 echo "--> copy new IIWA configuration files to IIWA container" >> /boot/intel-irris-auto-config.log
 docker cp intel_irris_devices.json waziup.intel-irris-waziapp:/root/src/config
-docker cp intel_irris_active_device.json waziup.intel-irris-waziapp:/root/src/config
 docker cp intel_irris_sensors_configurations.json waziup.intel-irris-waziapp:/root/src/config
 
 echo "--> removing IIWA configuration files" >> /boot/intel-irris-auto-config.log
-rm -rf intel_irris_devices.json intel_irris_active_device.json intel_irris_sensors_configurations.json
+rm -rf intel_irris_devices.json intel_irris_sensors_configurations.json
 
 
 

--- a/Gateway/boot/create-custom-multiple-range-iiwa/intel-irris-auto-config.sh
+++ b/Gateway/boot/create-custom-multiple-range-iiwa/intel-irris-auto-config.sh
@@ -6,11 +6,11 @@ cd /home/pi
 
 if [ $# -eq 0 ]
   then
-    FILE=/home/pi/boot/watermarks.txt
+    FILE=/boot/watermarks.txt
     if test -f "$FILE"; 
       then
         NWMS=`cat $FILE`
-        NCAPAS=`cat /home/pi/boot/capas.txt`
+        NCAPAS=`cat /boot/capas.txt`
         # echo "$FILE exists."
         ./boot/create-custom-multiple-range-iiwa/intel-irris-auto-config.sh $NCAPAS $NWMS
       else
@@ -24,8 +24,8 @@ if [ $# -eq 0 ]
   # else
 fi
 
-echo $1 > /home/pi/boot/capas.txt
-echo $2 > /home/pi/boot/watermarks.txt
+echo $1 > /boot/capas.txt
+echo $2 > /boot/watermarks.txt
 
 
 cd /home/pi/scripts


### PR DESCRIPTION
Solving bootstrap's incompatibility of custom multiple scripts that was due to mistaken relative paths. Adding the possibility to pre-configure custom multiple devices at bootstrap using a text file in /boot folder.