### PR TITLE
Transmit minimal measured voltage for non solar devices, default first measure

### DIFF
--- a/Arduino/Intelirris_Soil_Sensor/Intelirris_Soil_Sensor.ino
+++ b/Arduino/Intelirris_Soil_Sensor/Intelirris_Soil_Sensor.ino
@@ -19,7 +19,7 @@
  *  along with the program.  If not, see <http://www.gnu.org/licenses/>.
  *
  *****************************************************************************
- * last update: Apr. 12th, 2024 by C. Pham & Guillaume Gaillard
+ * last update: Apr. 29th, 2024 by C. Pham & Guillaume Gaillard
  * 
  * NEW: Support native LoRaWAN module RAK3172 with AT commands
  * 


### PR DESCRIPTION
Here, the voltage value that is radio transmitted in normal mode of execution of the device becomes the minimum measured value: min(value after sleep, value during tx, value after tx). In debug mode, the three values are sent.

Besides, the unknown values for the first cycle (values during and after tx are not measured yet at the time of the first transmission) are set to the value measured at first boot.

